### PR TITLE
fix: dont parse inputs

### DIFF
--- a/blocks/actions/dispatchWorkflow.ts
+++ b/blocks/actions/dispatchWorkflow.ts
@@ -57,15 +57,6 @@ export const dispatchWorkflow = defineGitHubBlock({
     const octokit = await getGitHubInstallation();
     const { owner, repo, workflowId, ref, inputs } = event.inputConfig;
 
-    let parsedInputs: Record<string, unknown> | undefined;
-    if (inputs) {
-      try {
-        parsedInputs = JSON.parse(inputs);
-      } catch {
-        throw new Error("Invalid JSON in inputs");
-      }
-    }
-
     await octokit.request(
       "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
       {
@@ -73,7 +64,7 @@ export const dispatchWorkflow = defineGitHubBlock({
         repo,
         workflow_id: workflowId,
         ref,
-        inputs: parsedInputs,
+        inputs,
       },
     );
 


### PR DESCRIPTION
The input expects an object, but the body of the block expects a string. This causes this block to be impossible to use because we try to parse something thats already an object.

Since the input expects an object, we can just cut out the JSON.parse bits and pass it directly into the request.